### PR TITLE
fix: add JSON instruction to system prompt for DeepSeek compatibility

### DIFF
--- a/pkg/agents/trading/trading_agent.go
+++ b/pkg/agents/trading/trading_agent.go
@@ -208,12 +208,17 @@ func (a *TradingAgent) GenActions(ctx context.Context, session types.ISession, m
 func (agent *TradingAgent) GenLLMMessages(sessionChats []string, msgs []*types.Message) ([]llms.MessageContent, error) {
 	llmMsgs := make([]llms.MessageContent, 0)
 
+	// Backgougroup — append JSON instruction to satisfy providers
+	// (e.g. DeepSeek) that require "json" in the prompt when
+	// response_format is set to json_object.
+	systemPrompt := agent.backgroup + "\n\nYou must respond in valid JSON format."
+
 	// Backgougroup
 	llmMsgs = append(llmMsgs, llms.MessageContent{
 		Role: llms.ChatMessageTypeSystem,
 		Parts: []llms.ContentPart{
 			llms.TextContent{
-				Text: agent.backgroup,
+				Text: systemPrompt,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- Append `"You must respond in valid JSON format."` to the system prompt in `GenLLMMessages()` to satisfy DeepSeek's requirement that the word "json" appears in the prompt when `response_format` is set to `json_object`

## Root Cause
The `release-0.33` branch added `llms.WithJSONMode()` which sets `response_format: json_object`. DeepSeek's API requires the word "json" in the prompt when this format is used, but the `backgroup` system prompt didn't contain it, causing a 400 error with `deepseek-v4-pro`.

## Test Plan
- [ ] Configure OpenAI provider with `base_url: "https://api.deepseek.com"` and `model: "deepseek-v4-pro"`
- [ ] Verify no 400 error on API calls
- [ ] Verify JSON responses are correctly parsed

Fixes #75