### PR TITLE
fix: bound goja arg evaluation with interrupt, stop sharing the runtime (#92, #93)

### DIFF
--- a/pkg/env/exchange/exchange_entity.go
+++ b/pkg/env/exchange/exchange_entity.go
@@ -54,7 +54,6 @@ type ExchangeEntity struct {
 	Indicators  []*ExchangeIndicator
 	KLineWindow *types.KLineWindow
 
-	vm                        *goja.Runtime
 	eventChannel              atomic.Value // Store chan ttypes.IEvent for thread-safe access
 	dynamicIndicatorCount     atomic.Int32 // Track dynamic indicator requests per cycle
 	dynamicIndicatorCycleTime time.Time    // Track current cycle start time
@@ -77,7 +76,6 @@ func NewExchangeEntity(
 		session:       session,
 		orderExecutor: orderExecutor,
 		position:      NewPositionX(position),
-		vm:            goja.New(),
 	}
 }
 
@@ -517,7 +515,7 @@ func (ent *ExchangeEntity) HandleCommand(ctx context.Context, cmd string, args m
 
 		// config stop losss
 		if stopLoss, ok := args["stop_loss_trigger_price"]; ok && stopLoss != "" {
-			stopLoss, err := utils.ParseStopLoss(ent.vm, side, closePrice, stopLoss)
+			stopLoss, err := utils.ParseStopLoss(goja.New(), side, closePrice, stopLoss)
 			if err != nil {
 				return errors.Wrapf(err, "the stop loss invalid: %s", stopLoss)
 			}
@@ -531,7 +529,7 @@ func (ent *ExchangeEntity) HandleCommand(ctx context.Context, cmd string, args m
 
 		// config take profix
 		if takeProfix, ok := args["take_profit_trigger_price"]; ok && takeProfix != "" {
-			takeProfix, err := utils.ParseTakeProfit(ent.vm, side, closePrice, takeProfix)
+			takeProfix, err := utils.ParseTakeProfit(goja.New(), side, closePrice, takeProfix)
 			if err != nil {
 				return errors.Wrapf(err, "the take profit invalid: %s", takeProfix)
 			}
@@ -552,7 +550,7 @@ func (ent *ExchangeEntity) HandleCommand(ctx context.Context, cmd string, args m
 
 		// config limit price
 		if limitPrice, ok := args["limit_price"]; ok && limitPrice != "" {
-			price, err := utils.ParsePrice(ent.vm, ent.KLineWindow, closePrice, limitPrice)
+			price, err := utils.ParsePrice(goja.New(), ent.KLineWindow, closePrice, limitPrice)
 			if err != nil {
 				return errors.Wrapf(err, "invalid limit_price: %s", limitPrice)
 			}

--- a/pkg/utils/args.go
+++ b/pkg/utils/args.go
@@ -2,10 +2,17 @@ package utils
 
 import (
 	"strings"
+	"time"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/dop251/goja"
 )
+
+// argEvalTimeout bounds evaluation of LLM-derived expressions. Legitimate
+// arguments are single arithmetic expressions that finish in microseconds;
+// anything hitting this limit is degenerate (e.g. while(true){}) and must not
+// hang the strategy goroutine.
+const argEvalTimeout = 500 * time.Millisecond
 
 func ExtractArgs(text string, cmd string) []string {
 	rets := make([]string, 0)
@@ -30,15 +37,27 @@ func ExtractArgs(text string, cmd string) []string {
 	return rets
 }
 
+// ArgToFixedpoint evaluates an LLM-derived expression on vm. The vm must not
+// be shared across goroutines (goja.Runtime is not goroutine-safe) — callers
+// should pass a fresh runtime per evaluation.
 func ArgToFixedpoint(vm *goja.Runtime, arg string) (*fixedpoint.Value, error) {
+	timer := time.AfterFunc(argEvalTimeout, func() {
+		vm.Interrupt("arg evaluation timed out")
+	})
+	defer timer.Stop()
+
 	v, err := vm.RunString(arg)
 	if err != nil {
 		return nil, err
 	}
 
-	num, ok := v.Export().(float64)
-	if ok {
+	// goja exports integer-valued results as int64, not float64.
+	switch num := v.Export().(type) {
+	case float64:
 		val := fixedpoint.NewFromFloat(num)
+		return &val, nil
+	case int64:
+		val := fixedpoint.NewFromInt(num)
 		return &val, nil
 	}
 

--- a/pkg/utils/args_test.go
+++ b/pkg/utils/args_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
@@ -62,4 +63,21 @@ func TestArgToFixedpointWithExpress(t *testing.T) {
 	val, err := ArgToFixedpoint(vm, "1.22*2")
 	assert.NoError(t, err)
 	assert.Equal(t, 2.44, val.Float64())
+}
+
+func TestArgToFixedpointIntegerResult(t *testing.T) {
+	vm := goja.New()
+	val, err := ArgToFixedpoint(vm, "70000")
+	assert.NoError(t, err)
+	assert.NotNil(t, val)
+	assert.Equal(t, 70000.0, val.Float64())
+}
+
+func TestArgToFixedpointInfiniteLoopTimesOut(t *testing.T) {
+	vm := goja.New()
+	start := time.Now()
+	val, err := ArgToFixedpoint(vm, "while(true){}")
+	assert.Error(t, err)
+	assert.Nil(t, val)
+	assert.Less(t, time.Since(start), 5*time.Second)
 }


### PR DESCRIPTION
## Problems (from live-deployment review)

1. **#92 — no time bound on LLM-derived expression eval**: `ArgToFixedpoint` runs model output through `vm.RunString` unguarded. A degenerate output like `while(true){}` in a price/stop_loss/take_profit arg hangs the strategy goroutine forever (no further candles, no TP/SL management).
2. **#93 — shared `goja.Runtime`**: the single `vm` on `ExchangeEntity` is reused across evaluations and reachable from multiple goroutines; `goja.Runtime` is not goroutine-safe. It also leaks state: kline variables bound by `ParsePrice` (`last_open`, `prev_close`, …) stay defined for later, unrelated stop-loss/take-profit evaluations.
3. **Bonus, same function**: integer-valued expressions are silently dropped — goja exports them as `int64`, and the `float64`-only type assertion returns `nil, nil`. A plain integer price like `70000` evaluates to nothing.

## Fix

- `ArgToFixedpoint` arms a 500ms `vm.Interrupt` watchdog (legitimate args are single arithmetic expressions that finish in microseconds), and accepts both `float64` and `int64` exports.
- `ExchangeEntity` no longer holds a shared runtime; each `ParsePrice` / `ParseStopLoss` / `ParseTakeProfit` call gets a fresh `goja.New()` — removes both the race and cross-eval variable leakage. No public signature changes.

## Testing

- New: `TestArgToFixedpointInfiniteLoopTimesOut` (returns error, bounded well under 5s), `TestArgToFixedpointIntegerResult` (70000 → 70000.0).
- `go test ./pkg/utils/ -race` green; `go build` / `go vet` on `pkg/utils` + `pkg/env/exchange` clean.

Fixes #92, fixes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)