### PR TITLE
fix(exchange): size position close off exchange-authoritative net (#89)

### DIFF
--- a/pkg/env/exchange/close_quantity.go
+++ b/pkg/env/exchange/close_quantity.go
@@ -1,0 +1,67 @@
+package exchange
+
+import "github.com/c9s/bbgo/pkg/fixedpoint"
+
+// closeSizing is the resolved sizing decision for closing (part of) a position.
+type closeSizing struct {
+	// BaseQuantity is the absolute base-asset quantity to submit for the close
+	// order. It is always <= the authoritative net position magnitude, so a
+	// market close can never cross zero and open an unintended opposite position.
+	BaseQuantity fixedpoint.Value
+	// SkipDust is true when the authoritative net position is below the market
+	// minimum quantity. In that case no closing order should be placed, because
+	// a reversing order for a dust remainder is exactly the #89 oversell/flip bug.
+	SkipDust bool
+}
+
+// resolveCloseBaseQuantity decides how much base asset to sell/buy to close a
+// position, using the exchange-authoritative net position when it is available
+// instead of the (potentially stale or gross) internally tracked base.
+//
+// Background (#89): handleCleanPosition queries the exchange for the real net
+// position to evaluate TP/SL triggers, but ClosePosition then sized the close
+// order off the internal ent.position base. When the internal base was larger
+// than the exchange net (gross vs net divergence, or leftover dust from a prior
+// round), the market close sold more than was actually held and flipped the
+// account into an unintended opposite position (observed: a stop-loss close
+// oversold and stayed short ~22h).
+//
+// The fix keeps direction handling in the caller and only governs magnitude:
+//   - prefer the authoritative net magnitude when hasAuthoritative is true;
+//   - never size larger than that magnitude (clamp defends against percentage>1);
+//   - treat a sub-minimum remainder as dust and skip the order entirely.
+func resolveCloseBaseQuantity(
+	internalBase fixedpoint.Value,
+	authoritativeNetBase fixedpoint.Value,
+	hasAuthoritative bool,
+	percentage fixedpoint.Value,
+	minQuantity fixedpoint.Value,
+) closeSizing {
+	effective := internalBase
+	if hasAuthoritative {
+		effective = authoritativeNetBase
+	}
+
+	magnitude := effective.Abs()
+
+	// Nothing (or only dust) actually held: do not place a reversing order.
+	if magnitude.Sign() == 0 || magnitude.Compare(minQuantity) < 0 {
+		return closeSizing{BaseQuantity: fixedpoint.Zero, SkipDust: true}
+	}
+
+	pct := percentage
+	if pct.Sign() <= 0 {
+		return closeSizing{BaseQuantity: fixedpoint.Zero, SkipDust: true}
+	}
+	if pct.Compare(fixedpoint.One) > 0 {
+		pct = fixedpoint.One
+	}
+
+	qty := magnitude.Mul(pct)
+	// Defensive clamp: a close order must never exceed the net position.
+	if qty.Compare(magnitude) > 0 {
+		qty = magnitude
+	}
+
+	return closeSizing{BaseQuantity: qty, SkipDust: false}
+}

--- a/pkg/env/exchange/close_quantity_test.go
+++ b/pkg/env/exchange/close_quantity_test.go
@@ -1,0 +1,129 @@
+package exchange
+
+import (
+	"testing"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+)
+
+func fp(s string) fixedpoint.Value { return fixedpoint.MustNewFromString(s) }
+
+func TestResolveCloseBaseQuantity(t *testing.T) {
+	minQty := fp("0.01")
+
+	cases := []struct {
+		name         string
+		internalBase string
+		authNetBase  string
+		hasAuth      bool
+		percentage   string
+		wantQty      string
+		wantSkipDust bool
+	}{
+		{
+			// #89 core: internal base is gross/stale and larger than the real
+			// exchange net. Sizing off internal would oversell and flip short;
+			// clamping to the authoritative net closes exactly what is held.
+			name:         "long_internal_gross_exceeds_exchange_net",
+			internalBase: "1.6046",
+			authNetBase:  "0.8",
+			hasAuth:      true,
+			percentage:   "1",
+			wantQty:      "0.8",
+			wantSkipDust: false,
+		},
+		{
+			// Exchange already flat: internal still thinks long -> must not
+			// place any sell (that sell is the unintended short).
+			name:         "long_internal_but_exchange_flat",
+			internalBase: "0.8",
+			authNetBase:  "0",
+			hasAuth:      true,
+			percentage:   "1",
+			wantQty:      "0",
+			wantSkipDust: true,
+		},
+		{
+			// Exchange net is sub-minimum dust: skip, do not reverse.
+			name:         "exchange_net_is_dust",
+			internalBase: "0.8",
+			authNetBase:  "0.004",
+			hasAuth:      true,
+			percentage:   "1",
+			wantQty:      "0",
+			wantSkipDust: true,
+		},
+		{
+			name:         "short_net_clamped_to_magnitude",
+			internalBase: "-2.0",
+			authNetBase:  "-1.2",
+			hasAuth:      true,
+			percentage:   "1",
+			wantQty:      "1.2",
+			wantSkipDust: false,
+		},
+		{
+			name:         "partial_close_half_of_net",
+			internalBase: "1.0",
+			authNetBase:  "1.0",
+			hasAuth:      true,
+			percentage:   "0.5",
+			wantQty:      "0.5",
+			wantSkipDust: false,
+		},
+		{
+			// No authoritative source -> fall back to internal base, still clamped.
+			name:         "no_authoritative_falls_back_to_internal",
+			internalBase: "0.8",
+			authNetBase:  "0",
+			hasAuth:      false,
+			percentage:   "1",
+			wantQty:      "0.8",
+			wantSkipDust: false,
+		},
+		{
+			// Defensive: percentage>1 must never exceed the net magnitude.
+			name:         "percentage_over_one_clamped",
+			internalBase: "1.0",
+			authNetBase:  "1.0",
+			hasAuth:      true,
+			percentage:   "1.5",
+			wantQty:      "1.0",
+			wantSkipDust: false,
+		},
+		{
+			name:         "nonpositive_percentage_skips",
+			internalBase: "1.0",
+			authNetBase:  "1.0",
+			hasAuth:      true,
+			percentage:   "0",
+			wantQty:      "0",
+			wantSkipDust: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveCloseBaseQuantity(
+				fp(tc.internalBase),
+				fp(tc.authNetBase),
+				tc.hasAuth,
+				fp(tc.percentage),
+				minQty,
+			)
+			if got.SkipDust != tc.wantSkipDust {
+				t.Fatalf("SkipDust = %v, want %v", got.SkipDust, tc.wantSkipDust)
+			}
+			if got.BaseQuantity.Compare(fp(tc.wantQty)) != 0 {
+				t.Fatalf("BaseQuantity = %v, want %v", got.BaseQuantity, tc.wantQty)
+			}
+			// Invariant: a resolved close never exceeds the net magnitude.
+			if !got.SkipDust {
+				netMag := fp(tc.authNetBase).Abs()
+				if tc.hasAuth && got.BaseQuantity.Compare(netMag) > 0 {
+					t.Fatalf("close qty %v exceeds authoritative net %v (would flip)", got.BaseQuantity, netMag)
+				}
+			}
+		})
+	}
+}

--- a/pkg/env/exchange/exchange_entity.go
+++ b/pkg/env/exchange/exchange_entity.go
@@ -1354,16 +1354,33 @@ func (s *ExchangeEntity) ClosePosition(ctx context.Context, percentage fixedpoin
 	posBeforeClose := *s.position
 	isFullClose := percentage.Compare(fixedpoint.One) == 0
 
-	// make it negative
-	quantity := s.position.GetBase().Mul(percentage).Abs()
+	// #89: size the close off the exchange-authoritative net position when it is
+	// available, not the internally tracked base which can be gross/stale. This
+	// prevents a market close from selling more than is actually held and
+	// flipping the account into an unintended opposite position.
+	authNetBase, hasAuth := s.queryAuthoritativeNetBase(ctx)
+	sizing := resolveCloseBaseQuantity(
+		s.position.GetBase(),
+		authNetBase,
+		hasAuth,
+		percentage,
+		s.position.Market.MinQuantity,
+	)
+	if sizing.SkipDust {
+		log.WithField("symbol", s.symbol).
+			WithField("internalBase", s.position.GetBase()).
+			WithField("authoritativeNetBase", authNetBase).
+			WithField("hasAuthoritative", hasAuth).
+			WithField("minQuantity", s.position.Market.MinQuantity).
+			Info("ClosePosition_skip_dust_no_reverse_order")
+		return nil
+	}
+
+	quantity := sizing.BaseQuantity
 	side := types.SideTypeBuy
 
 	if s.position.IsLong() {
 		side = types.SideTypeSell
-
-		if quantity.Compare(s.position.Market.MinQuantity) < 0 {
-			return fmt.Errorf("%s order quantity %v is too small, less than %v", s.symbol, quantity, s.position.Market.MinQuantity)
-		}
 	} else {
 		quantity = quantity.Mul(closePrice)
 	}
@@ -1439,6 +1456,30 @@ func (s *ExchangeEntity) ClosePosition(ctx context.Context, percentage fixedpoin
 	}
 
 	return err
+}
+
+// queryAuthoritativeNetBase best-effort reads the exchange's real net position
+// base for the traded symbol. It returns (base, true) on success and
+// (zero, false) when the exchange does not expose position info or the query
+// fails, in which case callers fall back to the internally tracked base.
+func (s *ExchangeEntity) queryAuthoritativeNetBase(ctx context.Context) (fixedpoint.Value, bool) {
+	service, implemented := s.session.Exchange.(types.ExchangePositionUpdateService)
+	if !implemented {
+		return fixedpoint.Zero, false
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*20)
+	defer cancel()
+
+	posInfo, err := service.QueryPositionInfo(queryCtx, s.symbol)
+	if err != nil || posInfo == nil {
+		log.WithError(err).
+			WithField("symbol", s.symbol).
+			Warn("ClosePosition_queryAuthoritativeNetBase_fail_fallback_to_internal")
+		return fixedpoint.Zero, false
+	}
+
+	return posInfo.Base, true
 }
 
 func (s *ExchangeEntity) UpdatePosition(ctx context.Context, side types.SideType, closePrice fixedpoint.Value, args ...interface{}) error {


### PR DESCRIPTION
## Problem (#89)

`ExchangeEntity.ClosePosition` sized the close order off the internally tracked `s.position` base. That value can diverge **above** the real exchange net position — gross-vs-net accounting, or leftover dust from a prior round-trip. Because the close is a market order, selling more base than is actually held crosses zero and opens an **unintended opposite position**.

Observed in a live run: a stop-loss close oversold the net and left the account short for ~22h.

`handleCleanPosition` already queries the exchange for the authoritative net position (`QueryPositionInfo`) to evaluate TP/SL triggers, but the subsequent `ClosePosition` ignored it and re-sized off the internal base.

## Fix

- Size the close off the **exchange-authoritative net** (`QueryPositionInfo().Base`) when the exchange exposes `ExchangePositionUpdateService`; fall back to the internal base otherwise.
- **Clamp** the close quantity so it can never exceed the net magnitude (defends against `percentage > 1` and residual divergence) → a close can no longer flip to the opposite side.
- **Skip** placing any order when the authoritative net is sub-`MinQuantity` dust — a reversing order for a dust remainder is exactly the bug.
- Extracted `resolveCloseBaseQuantity` as a pure, unit-tested helper; direction handling (long→Sell, short→Buy) and the existing short-side notional conversion are unchanged.

## Tests

- New `pkg/env/exchange/close_quantity_test.go`: internal-gross-exceeds-net (the #89 case), exchange-already-flat, dust net, short clamp, partial close, no-authoritative fallback, `percentage>1` clamp, non-positive percentage — each asserting "close never exceeds authoritative net".
- `go test ./pkg/env/exchange/` PASS, `go vet ./pkg/env/exchange/` clean, `go build ./pkg/env/exchange/` PASS (Go 1.22 toolchain, matching the module's `go 1.22.0`).

Fixes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)