### PR TITLE
fix(exchange): add idempotency guard to prevent duplicate order submissions (#94)

### DIFF
--- a/pkg/env/exchange/exchange_entity.go
+++ b/pkg/env/exchange/exchange_entity.go
@@ -58,6 +58,7 @@ type ExchangeEntity struct {
 	eventChannel              atomic.Value // Store chan ttypes.IEvent for thread-safe access
 	dynamicIndicatorCount     atomic.Int32 // Track dynamic indicator requests per cycle
 	dynamicIndicatorCycleTime time.Time    // Track current cycle start time
+	orderDedup                *orderDedupGuard // Idempotency guard for order submissions (#94)
 }
 
 func NewExchangeEntity(
@@ -78,7 +79,20 @@ func NewExchangeEntity(
 		orderExecutor: orderExecutor,
 		position:      NewPositionX(position),
 		vm:            goja.New(),
+		orderDedup:    newOrderDedupGuard(),
 	}
+}
+
+// currentCycle returns the start time of the most recent kline, used as the
+// idempotency cycle boundary for order deduplication. It returns the zero time
+// when no kline data is available, which disables deduplication for that call
+// and preserves the legacy submission behaviour.
+func (s *ExchangeEntity) currentCycle() time.Time {
+	if s.KLineWindow == nil || s.KLineWindow.Len() == 0 {
+		return time.Time{}
+	}
+
+	return s.KLineWindow.Last().StartTime.Time()
 }
 
 func (ent *ExchangeEntity) GetID() string {
@@ -1299,6 +1313,18 @@ func (s *ExchangeEntity) OpenPosition(ctx context.Context, side types.SideType, 
 
 	quantity := s.calculateQuantity(ctx, closePrice, side, quoteRatio)
 
+	// Idempotency guard (#94): suppress duplicate open submissions for the same
+	// side within the same kline cycle (e.g. a repeated signal dispatch or a
+	// network-retried command). Claimed before the submit loop so the
+	// Insufficient-USDT retry below is not self-blocked.
+	if key, first := s.orderDedup.claim(s.symbol, OpenIntent(side), s.currentCycle()); !first {
+		log.WithField("idempotencyKey", key).
+			WithField("symbol", s.symbol).
+			WithField("side", side.String()).
+			Warn("skip duplicate open position submission within the same kline cycle")
+		return nil
+	}
+
 	for {
 		if quantity.Compare(s.position.Market.MinQuantity) < 0 {
 			return fmt.Errorf("%s order quantity %v is too small, less than %v", s.symbol, quantity, s.position.Market.MinQuantity)
@@ -1366,6 +1392,18 @@ func (s *ExchangeEntity) ClosePosition(ctx context.Context, percentage fixedpoin
 		}
 	} else {
 		quantity = quantity.Mul(closePrice)
+	}
+
+	// Idempotency guard (#94): suppress duplicate close submissions for the same
+	// close percentage within the same kline cycle (e.g. a network-retried close
+	// command or a re-triggered TP/SL). Distinct partial-close percentages map to
+	// distinct intents and are not blocked.
+	if key, first := s.orderDedup.claim(s.symbol, CloseIntent(percentage), s.currentCycle()); !first {
+		log.WithField("idempotencyKey", key).
+			WithField("symbol", s.symbol).
+			WithField("percentage", percentage.Float64()).
+			Warn("skip duplicate close position submission within the same kline cycle")
+		return nil
 	}
 
 	orderForm := s.generateOrderForm(side, quantity, types.SideEffectTypeAutoRepay)

--- a/pkg/env/exchange/order_idempotency.go
+++ b/pkg/env/exchange/order_idempotency.go
@@ -1,0 +1,107 @@
+package exchange
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+// OrderIntent identifies the semantic operation an order submission represents.
+// Two submissions that share the same intent within the same kline cycle are
+// treated as duplicates (typically caused by a network retry or a repeated
+// signal dispatch) and only the first one is allowed through.
+type OrderIntent string
+
+const (
+	IntentOpenLong  OrderIntent = "open_long"
+	IntentOpenShort OrderIntent = "open_short"
+	IntentClose     OrderIntent = "close"
+)
+
+// OpenIntent maps an order side to the corresponding open-position intent.
+func OpenIntent(side types.SideType) OrderIntent {
+	if side == types.SideTypeSell {
+		return IntentOpenShort
+	}
+	return IntentOpenLong
+}
+
+// CloseIntent builds a close intent discriminated by the close percentage so
+// that genuinely distinct partial closes within one cycle are not wrongly
+// blocked, while identical close retries are deduplicated.
+func CloseIntent(percentage fixedpoint.Value) OrderIntent {
+	return OrderIntent(fmt.Sprintf("%s:%s", IntentClose, percentage.String()))
+}
+
+// BuildIdempotencyKey returns a deterministic key for an order submission.
+//
+// The key is stable across retries of the same intent within the same kline
+// cycle and changes when the symbol, the intent, or the cycle changes. cycle is
+// normalised to the kline start time in unix milliseconds. A zero cycle or an
+// empty symbol yields an empty key, which signals "no idempotency context is
+// available" and disables deduplication for that call (preserving legacy
+// behaviour for callers without kline data).
+func BuildIdempotencyKey(symbol string, intent OrderIntent, cycle time.Time) string {
+	if cycle.IsZero() || symbol == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s|%s|%d", symbol, intent, cycle.UnixMilli())
+}
+
+// orderDedupGuard tracks which idempotency keys have already been claimed in the
+// current kline cycle. It is safe for concurrent use.
+//
+// The guard claims a key *before* the order is submitted and never releases it
+// within the cycle, even if the submission returns an error. This is the
+// conservative choice for #94: the most dangerous failure mode is a submission
+// that times out locally but actually reached the exchange; releasing the claim
+// on error would let the retry create a real duplicate order. By keeping the
+// claim, a duplicate dispatch is suppressed for the rest of the cycle and the
+// strategy simply re-evaluates on the next kline.
+type orderDedupGuard struct {
+	mu    sync.Mutex
+	cycle time.Time
+	seen  map[string]struct{}
+}
+
+func newOrderDedupGuard() *orderDedupGuard {
+	return &orderDedupGuard{seen: make(map[string]struct{})}
+}
+
+// tryClaim records key for the given cycle and reports whether the caller should
+// proceed with the submission. It returns true the first time a key is seen
+// within a cycle and false for subsequent duplicates. When the cycle advances,
+// previously seen keys are evicted so the same intent may run again. An empty key
+// (no idempotency context) always returns true and is never recorded.
+func (g *orderDedupGuard) tryClaim(key string, cycle time.Time) bool {
+	if key == "" {
+		return true
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if !g.cycle.Equal(cycle) {
+		g.cycle = cycle
+		g.seen = make(map[string]struct{})
+	}
+
+	if _, ok := g.seen[key]; ok {
+		return false
+	}
+
+	g.seen[key] = struct{}{}
+	return true
+}
+
+// claim builds the idempotency key for the given intent and cycle and attempts
+// to claim it. It returns the key (for logging) and whether this is the first
+// submission for that key within the cycle.
+func (g *orderDedupGuard) claim(symbol string, intent OrderIntent, cycle time.Time) (string, bool) {
+	key := BuildIdempotencyKey(symbol, intent, cycle)
+	return key, g.tryClaim(key, cycle)
+}

--- a/pkg/env/exchange/order_idempotency_test.go
+++ b/pkg/env/exchange/order_idempotency_test.go
@@ -1,0 +1,151 @@
+package exchange
+
+import (
+	"testing"
+	"time"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+func TestOpenIntent(t *testing.T) {
+	if got := OpenIntent(types.SideTypeBuy); got != IntentOpenLong {
+		t.Fatalf("OpenIntent(Buy) = %q, want %q", got, IntentOpenLong)
+	}
+	if got := OpenIntent(types.SideTypeSell); got != IntentOpenShort {
+		t.Fatalf("OpenIntent(Sell) = %q, want %q", got, IntentOpenShort)
+	}
+}
+
+func TestCloseIntentDiscriminatesByPercentage(t *testing.T) {
+	full := CloseIntent(fixedpoint.One)
+	half := CloseIntent(fixedpoint.NewFromFloat(0.5))
+
+	if full == half {
+		t.Fatalf("expected distinct intents for distinct percentages, both = %q", full)
+	}
+
+	// Same percentage must be stable (deterministic).
+	if again := CloseIntent(fixedpoint.One); again != full {
+		t.Fatalf("CloseIntent(1) not deterministic: %q vs %q", again, full)
+	}
+}
+
+func TestBuildIdempotencyKey(t *testing.T) {
+	cycle := time.Unix(1_700_000_000, 0)
+
+	k1 := BuildIdempotencyKey("BTCUSDT", IntentOpenLong, cycle)
+	if k1 == "" {
+		t.Fatal("expected non-empty key for valid inputs")
+	}
+
+	// Deterministic for identical inputs.
+	if k2 := BuildIdempotencyKey("BTCUSDT", IntentOpenLong, cycle); k1 != k2 {
+		t.Fatalf("key not deterministic: %q vs %q", k1, k2)
+	}
+
+	// Changing any field changes the key.
+	if k := BuildIdempotencyKey("ETHUSDT", IntentOpenLong, cycle); k == k1 {
+		t.Fatal("expected different key for different symbol")
+	}
+	if k := BuildIdempotencyKey("BTCUSDT", IntentOpenShort, cycle); k == k1 {
+		t.Fatal("expected different key for different intent")
+	}
+	if k := BuildIdempotencyKey("BTCUSDT", IntentOpenLong, cycle.Add(time.Minute)); k == k1 {
+		t.Fatal("expected different key for different cycle")
+	}
+
+	// Zero cycle or empty symbol => empty key (no idempotency context).
+	if k := BuildIdempotencyKey("BTCUSDT", IntentOpenLong, time.Time{}); k != "" {
+		t.Fatalf("expected empty key for zero cycle, got %q", k)
+	}
+	if k := BuildIdempotencyKey("", IntentOpenLong, cycle); k != "" {
+		t.Fatalf("expected empty key for empty symbol, got %q", k)
+	}
+}
+
+// Same intent submitted twice in the same cycle: only the first proceeds.
+func TestGuardSameIntentSubmittedOnce(t *testing.T) {
+	g := newOrderDedupGuard()
+	cycle := time.Unix(1_700_000_000, 0)
+
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, cycle); !first {
+		t.Fatal("first claim should proceed")
+	}
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, cycle); first {
+		t.Fatal("duplicate claim in same cycle should be suppressed")
+	}
+	// A third identical retry must also stay suppressed.
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, cycle); first {
+		t.Fatal("further duplicate claims in same cycle should stay suppressed")
+	}
+}
+
+// Different intents in the same cycle each proceed independently.
+func TestGuardDifferentIntentsEachSubmit(t *testing.T) {
+	g := newOrderDedupGuard()
+	cycle := time.Unix(1_700_000_000, 0)
+
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, cycle); !first {
+		t.Fatal("open_long should proceed")
+	}
+	if _, first := g.claim("BTCUSDT", IntentOpenShort, cycle); !first {
+		t.Fatal("open_short is a distinct intent and should proceed")
+	}
+	if _, first := g.claim("BTCUSDT", CloseIntent(fixedpoint.One), cycle); !first {
+		t.Fatal("close is a distinct intent and should proceed")
+	}
+	if _, first := g.claim("BTCUSDT", CloseIntent(fixedpoint.NewFromFloat(0.5)), cycle); !first {
+		t.Fatal("a different close percentage is a distinct intent and should proceed")
+	}
+	// A different symbol is also independent.
+	if _, first := g.claim("ETHUSDT", IntentOpenLong, cycle); !first {
+		t.Fatal("different symbol should proceed")
+	}
+}
+
+// The same intent is allowed again once the kline cycle advances.
+func TestGuardAllowsResubmitAcrossCycles(t *testing.T) {
+	g := newOrderDedupGuard()
+	c1 := time.Unix(1_700_000_000, 0)
+	c2 := c1.Add(5 * time.Minute)
+
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, c1); !first {
+		t.Fatal("first claim in cycle 1 should proceed")
+	}
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, c1); first {
+		t.Fatal("duplicate in cycle 1 should be suppressed")
+	}
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, c2); !first {
+		t.Fatal("same intent in a new cycle should proceed again")
+	}
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, c2); first {
+		t.Fatal("duplicate in cycle 2 should be suppressed")
+	}
+}
+
+// With no idempotency context (empty key), every call proceeds and nothing is
+// recorded, preserving legacy behaviour for callers without kline data.
+func TestGuardEmptyKeyAlwaysProceeds(t *testing.T) {
+	g := newOrderDedupGuard()
+
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, time.Time{}); !first {
+		t.Fatal("zero cycle should proceed (no dedup context)")
+	}
+	if _, first := g.claim("BTCUSDT", IntentOpenLong, time.Time{}); !first {
+		t.Fatal("zero cycle should keep proceeding (never recorded)")
+	}
+	if _, first := g.claim("", IntentOpenLong, time.Unix(1_700_000_000, 0)); !first {
+		t.Fatal("empty symbol should proceed (no dedup context)")
+	}
+}
+
+func TestTryClaimEmptyKey(t *testing.T) {
+	g := newOrderDedupGuard()
+	if !g.tryClaim("", time.Unix(1, 0)) {
+		t.Fatal("empty key must always proceed")
+	}
+	if !g.tryClaim("", time.Unix(2, 0)) {
+		t.Fatal("empty key must always proceed regardless of cycle")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #94.

The exchange entity's order-submission path had no client order id / idempotency key. A network-retried command or a re-dispatched signal could reach `orderExecutor.SubmitOrders` twice within the same kline cycle and place a **duplicate real order** (duplicate open/close on the live account).

### Root cause
`generateOrderForm` (`pkg/env/exchange/exchange_entity.go`) never set `ClientOrderID`, and both submission sites — `OpenPosition` and `ClosePosition` (which also back TP/SL and emergency close) — submitted with no dedup. Nothing prevented the same intent from being submitted twice in one cycle.

### Fix
A deterministic, per-kline-cycle deduplication guard (`pkg/env/exchange/order_idempotency.go`) wraps the two submission paths. It claims a stable idempotency key `symbol + intent + kline-start-time` **before** submitting and does **not** release it within the cycle even on error, so a submit that times out locally but actually reached the exchange cannot be duplicated by a retry.

- Distinct sides and distinct close percentages map to distinct intents and are never wrongly blocked.
- The same intent is allowed again once the kline cycle advances.
- Callers without kline data (empty key) keep the legacy behaviour.
- First-submission behaviour is unchanged; the Insufficient-USDT retry loop is claimed once before the loop and is not self-blocked.

### Why an entity-layer guard (not bbgo/OKX ClientOrderID)
bbgo does support `SubmitOrder.ClientOrderID` and the OKX adapter transports it, but its cross-cycle uniqueness-window semantics are not guaranteed, and OKX enforces a strict `^[a-zA-Z0-9]{0,32}$` regex plus duplicate-rejection that could reject legitimate retries (e.g. the Insufficient-USDT resize loop) on the live path. The entity-layer guard is more conservative and fully testable, and does not touch the bbgo submodule.

### Tests
`GOTOOLCHAIN=go1.22.0 go test ./pkg/env/exchange/` — 8 new unit tests pass, covering key generation, same-intent-once, distinct-intents, cross-cycle re-allow, and empty-key passthrough. `go vet` clean, `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)