### PR TITLE
fix(exchange): add goja eval timeout and serialize shared runtime (#92, #93)

### DIFF
--- a/pkg/env/exchange/exchange_entity.go
+++ b/pkg/env/exchange/exchange_entity.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -54,7 +55,9 @@ type ExchangeEntity struct {
 	Indicators  []*ExchangeIndicator
 	KLineWindow *types.KLineWindow
 
-	vm                        *goja.Runtime
+	vm   *goja.Runtime
+	vmMu sync.Mutex // serializes access to vm; goja.Runtime is not thread-safe (issue #93)
+
 	eventChannel              atomic.Value // Store chan ttypes.IEvent for thread-safe access
 	dynamicIndicatorCount     atomic.Int32 // Track dynamic indicator requests per cycle
 	dynamicIndicatorCycleTime time.Time    // Track current cycle start time
@@ -319,6 +322,18 @@ func (ent *ExchangeEntity) Actions() []*ttypes.ActionDesc {
 	}
 }
 
+// evalWithVM serializes access to the shared goja runtime (ent.vm) so that
+// concurrent command handling cannot race on it (issue #93). The runtime is not
+// safe for concurrent use, and callers set variables on it before evaluating an
+// expression, so the whole set+eval sequence must be held under the lock. The
+// per-eval timeout that guards against runaway scripts (issue #92) lives in
+// utils.ArgToFixedpoint.
+func (ent *ExchangeEntity) evalWithVM(fn func(vm *goja.Runtime) (*fixedpoint.Value, error)) (*fixedpoint.Value, error) {
+	ent.vmMu.Lock()
+	defer ent.vmMu.Unlock()
+	return fn(ent.vm)
+}
+
 func (ent *ExchangeEntity) cmdToSide(cmd string) types.SideType {
 	switch cmd {
 	case "open_long_position":
@@ -517,7 +532,9 @@ func (ent *ExchangeEntity) HandleCommand(ctx context.Context, cmd string, args m
 
 		// config stop losss
 		if stopLoss, ok := args["stop_loss_trigger_price"]; ok && stopLoss != "" {
-			stopLoss, err := utils.ParseStopLoss(ent.vm, side, closePrice, stopLoss)
+			stopLoss, err := ent.evalWithVM(func(vm *goja.Runtime) (*fixedpoint.Value, error) {
+				return utils.ParseStopLoss(vm, side, closePrice, stopLoss)
+			})
 			if err != nil {
 				return errors.Wrapf(err, "the stop loss invalid: %s", stopLoss)
 			}
@@ -531,7 +548,9 @@ func (ent *ExchangeEntity) HandleCommand(ctx context.Context, cmd string, args m
 
 		// config take profix
 		if takeProfix, ok := args["take_profit_trigger_price"]; ok && takeProfix != "" {
-			takeProfix, err := utils.ParseTakeProfit(ent.vm, side, closePrice, takeProfix)
+			takeProfix, err := ent.evalWithVM(func(vm *goja.Runtime) (*fixedpoint.Value, error) {
+				return utils.ParseTakeProfit(vm, side, closePrice, takeProfix)
+			})
 			if err != nil {
 				return errors.Wrapf(err, "the take profit invalid: %s", takeProfix)
 			}
@@ -552,7 +571,9 @@ func (ent *ExchangeEntity) HandleCommand(ctx context.Context, cmd string, args m
 
 		// config limit price
 		if limitPrice, ok := args["limit_price"]; ok && limitPrice != "" {
-			price, err := utils.ParsePrice(ent.vm, ent.KLineWindow, closePrice, limitPrice)
+			price, err := ent.evalWithVM(func(vm *goja.Runtime) (*fixedpoint.Value, error) {
+				return utils.ParsePrice(vm, ent.KLineWindow, closePrice, limitPrice)
+			})
 			if err != nil {
 				return errors.Wrapf(err, "invalid limit_price: %s", limitPrice)
 			}

--- a/pkg/env/exchange/exchange_entity_vm_test.go
+++ b/pkg/env/exchange/exchange_entity_vm_test.go
@@ -1,0 +1,89 @@
+package exchange
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/yubing744/trading-gpt/pkg/utils"
+)
+
+// TestEvalWithVM_ConcurrentNoRace exercises the shared goja runtime from many
+// goroutines through evalWithVM. Without the mutex, goja.Runtime access races
+// (issue #93). Run with -race to catch regressions. With the lock, each
+// goroutine also gets the correct, isolated result.
+func TestEvalWithVM_ConcurrentNoRace(t *testing.T) {
+	ent := &ExchangeEntity{vm: goja.New()}
+
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	errs := make([]error, workers)
+	results := make([]float64, workers)
+
+	for i := 0; i < workers; i++ {
+		go func(idx int) {
+			defer wg.Done()
+
+			closePrice := fixedpoint.NewFromInt(int64(100 + idx))
+			// ParsePrice sets variables on the shared vm and then evaluates,
+			// so the whole set+eval sequence must be serialized by evalWithVM.
+			// Use a non-integral multiplier so goja exports a float64 result.
+			val, err := ent.evalWithVM(func(vm *goja.Runtime) (*fixedpoint.Value, error) {
+				return utils.ParsePrice(vm, nil, closePrice, "last_close * 0.995")
+			})
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			if val != nil {
+				results[idx] = val.Float64()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < workers; i++ {
+		assert.NoError(t, errs[i])
+		expected := float64(100+i) * 0.995
+		assert.InDelta(t, expected, results[i], 1e-6, "worker %d got wrong result", i)
+	}
+}
+
+// TestEvalWithVM_TimeoutDoesNotHang verifies that a runaway script routed
+// through the shared runtime is interrupted and does not hang the caller
+// (issues #92 + #93 combined path).
+func TestEvalWithVM_TimeoutDoesNotHang(t *testing.T) {
+	ent := &ExchangeEntity{vm: goja.New()}
+
+	done := make(chan struct{})
+	var err error
+
+	go func() {
+		_, err = ent.evalWithVM(func(vm *goja.Runtime) (*fixedpoint.Value, error) {
+			return utils.ArgToFixedpointWithTimeout(vm, "while (true) {}", 200*time.Millisecond)
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		assert.Error(t, err, "runaway script must return an error, not hang")
+	case <-time.After(5 * time.Second):
+		t.Fatal("evalWithVM hung on a runaway script")
+	}
+
+	// The lock must be released after a timeout so the runtime stays usable.
+	val, err := ent.evalWithVM(func(vm *goja.Runtime) (*fixedpoint.Value, error) {
+		return utils.ArgToFixedpointWithTimeout(vm, "1.5 + 1", time.Second)
+	})
+	assert.NoError(t, err)
+	if assert.NotNil(t, val) {
+		assert.InDelta(t, 2.5, val.Float64(), 1e-9)
+	}
+}

--- a/pkg/utils/args.go
+++ b/pkg/utils/args.go
@@ -2,10 +2,17 @@ package utils
 
 import (
 	"strings"
+	"time"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/dop251/goja"
 )
+
+// DefaultEvalTimeout bounds how long a single goja expression evaluation may run
+// before it is interrupted. It guards the decision loop against malicious,
+// pathological, or infinite-loop scripts produced by the LLM (issue #92).
+// It is a variable so it can be tuned by operators if needed.
+var DefaultEvalTimeout = 5 * time.Second
 
 func ExtractArgs(text string, cmd string) []string {
 	rets := make([]string, 0)
@@ -30,8 +37,42 @@ func ExtractArgs(text string, cmd string) []string {
 	return rets
 }
 
+// ArgToFixedpoint evaluates a JavaScript expression using the provided goja
+// runtime and converts the result to a fixedpoint value. Evaluation is bounded
+// by DefaultEvalTimeout so a runaway (e.g. infinite-loop) script cannot hang the
+// caller (issue #92).
+//
+// NOTE: goja.Runtime is NOT safe for concurrent use. Callers that share a single
+// runtime across goroutines must serialize access to it (see
+// ExchangeEntity.vmMu / evalWithVM), issue #93.
 func ArgToFixedpoint(vm *goja.Runtime, arg string) (*fixedpoint.Value, error) {
+	return ArgToFixedpointWithTimeout(vm, arg, DefaultEvalTimeout)
+}
+
+// ArgToFixedpointWithTimeout is like ArgToFixedpoint but with an explicit
+// evaluation timeout. A non-positive timeout disables the timeout guard.
+//
+// The timeout is enforced via goja's Interrupt mechanism: a timer fires
+// vm.Interrupt from another goroutine, which causes the in-flight RunString to
+// return an *goja.InterruptedError instead of hanging. Note that Interrupt only
+// affects JavaScript execution, not native Go built-ins.
+func ArgToFixedpointWithTimeout(vm *goja.Runtime, arg string, timeout time.Duration) (*fixedpoint.Value, error) {
+	var timer *time.Timer
+	if timeout > 0 {
+		timer = time.AfterFunc(timeout, func() {
+			vm.Interrupt("execution timeout")
+		})
+	}
+
 	v, err := vm.RunString(arg)
+
+	if timer != nil {
+		timer.Stop()
+		// Reset the interrupt flag so the (possibly shared) runtime is safe to
+		// reuse, even if the timer fired right as RunString was returning.
+		vm.ClearInterrupt()
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/args_timeout_test.go
+++ b/pkg/utils/args_timeout_test.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestArgToFixedpoint_NormalExpression verifies that a normal expression still
+// evaluates correctly with the default timeout in place (issue #92 must not
+// change happy-path behaviour).
+func TestArgToFixedpoint_NormalExpression(t *testing.T) {
+	vm := goja.New()
+
+	val, err := ArgToFixedpoint(vm, "1.22 * 4")
+	assert.NoError(t, err)
+	if assert.NotNil(t, val) {
+		assert.InDelta(t, 4.88, val.Float64(), 1e-9)
+	}
+}
+
+// TestArgToFixedpointWithTimeout_InterruptsRunawayScript verifies that an
+// infinite-loop script is interrupted and returns an error rather than hanging
+// the caller (issue #92).
+func TestArgToFixedpointWithTimeout_InterruptsRunawayScript(t *testing.T) {
+	vm := goja.New()
+
+	start := time.Now()
+	val, err := ArgToFixedpointWithTimeout(vm, "while (true) {}", 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err, "runaway script must return an error")
+	assert.Nil(t, val)
+	// Must have returned promptly around the timeout, not hung.
+	assert.Less(t, elapsed, 3*time.Second, "eval should be interrupted near the timeout, not hang")
+
+	// The interrupt payload should surface in the error.
+	assert.Contains(t, err.Error(), "execution timeout")
+}
+
+// TestArgToFixedpointWithTimeout_NormalUnaffected verifies that a fast, valid
+// expression completes normally even with a short timeout configured.
+func TestArgToFixedpointWithTimeout_NormalUnaffected(t *testing.T) {
+	vm := goja.New()
+
+	val, err := ArgToFixedpointWithTimeout(vm, "100 * 0.995", 5*time.Second)
+	assert.NoError(t, err)
+	if assert.NotNil(t, val) {
+		assert.InDelta(t, 99.5, val.Float64(), 1e-9)
+	}
+}
+
+// TestArgToFixedpointWithTimeout_RuntimeReusableAfterInterrupt verifies that the
+// interrupt flag is cleared, so the same runtime can be reused after a timeout.
+func TestArgToFixedpointWithTimeout_RuntimeReusableAfterInterrupt(t *testing.T) {
+	vm := goja.New()
+
+	_, err := ArgToFixedpointWithTimeout(vm, "while (true) {}", 100*time.Millisecond)
+	assert.Error(t, err)
+
+	// Reusing the same runtime must work (ClearInterrupt was called).
+	val, err := ArgToFixedpointWithTimeout(vm, "1.5 + 5", 5*time.Second)
+	assert.NoError(t, err)
+	if assert.NotNil(t, val) {
+		assert.InDelta(t, 6.5, val.Float64(), 1e-9)
+	}
+}


### PR DESCRIPTION
## Summary

LLM-produced expressions (stop-loss / take-profit / limit-price) are evaluated by goja (`vm.RunString`) via `utils.ArgToFixedpoint`, using the single shared `ExchangeEntity.vm`. This PR fixes two related safety issues in that path.

### #92 — goja eval had no timeout
A malicious, oversized, or infinite-loop expression from the model could hang the decision loop (a real risk for a live strategy). Every evaluation is now bounded by a configurable timeout (default `5s`, `utils.DefaultEvalTimeout`), enforced with goja's documented Interrupt idiom:

- `time.AfterFunc(timeout, func() { vm.Interrupt("execution timeout") })`
- run `vm.RunString`, then `timer.Stop()` + `vm.ClearInterrupt()` so the runtime stays reusable.

On timeout the call returns an error (`*goja.InterruptedError`) instead of hanging.

### #93 — shared goja runtime accessed without synchronization
`goja.Runtime` is not thread-safe, yet `ExchangeEntity.vm` is shared and each command does `vm.Set(...)` then evaluates. Concurrent command handling could data-race. All shared-vm access is now serialized behind a `sync.Mutex` via a small `evalWithVM` helper that wraps the whole set-variables + eval sequence.

## Changes
- `pkg/utils/args.go`: `ArgToFixedpoint` now delegates to a new `ArgToFixedpointWithTimeout`; timeout via Interrupt + ClearInterrupt. Public signatures unchanged, so existing callers/tests are unaffected. All three eval paths (`ParsePrice`, `ParseStopLoss`, `ParseTakeProfit`) inherit the timeout automatically.
- `pkg/env/exchange/exchange_entity.go`: add `vmMu sync.Mutex` + `evalWithVM`; the three eval call sites now go through it.
- Tests: `pkg/utils/args_timeout_test.go`, `pkg/env/exchange/exchange_entity_vm_test.go`.

## Testing
- `GOTOOLCHAIN=go1.22.0 go test ./pkg/utils/ ./pkg/env/exchange/ -race` — PASS
- `go vet ./...` — clean
- `go build ./...` — PASS

New tests cover: runaway `while(true){}` script is interrupted and returns promptly (no hang), normal expressions still evaluate, the runtime is reusable after an interrupt, and 32 concurrent evals through the shared runtime are correct and race-clean.

## Scope
Conservative: no behavior change on the normal/first eval path, no unrelated code touched, no submodule bumps.

Fixes #92
Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)