### PR TITLE
feat(exchange): code-level hard risk-control gate & kill-switch (#86)

### DIFF
--- a/pkg/config/env_exchange_config.go
+++ b/pkg/config/env_exchange_config.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
 )
 
@@ -100,9 +101,60 @@ type EnvExchangeConfig struct {
 	Indicators          map[string]*IndicatorConfig `json:"indicators"`
 	HandlePositionClose bool                        `json:"handle_position_close"`
 	CleanPosition       CleanPositionConfig         `json:"clean_position"`
+	RiskControl         RiskControlConfig           `json:"risk_control"`
 }
 
 type CleanPositionConfig struct {
 	Enabled  bool           `json:"enabled"`
 	Interval types.Interval `json:"interval"`
+}
+
+// RiskControlConfig defines code-level hard risk-control gates that operate
+// independently of the LLM decision. Any configured limit that is breached
+// causes the corresponding order submission to be rejected (defensive deny),
+// never a new/active order. See issue #86 (KR3).
+//
+// Threshold semantics: a zero (unset) limit disables that individual check,
+// so an unconfigured deployment keeps its exact prior behaviour. Operators
+// tighten the gate by setting positive thresholds (recommended, sized to the
+// live account). The master `enabled` switch defaults to true.
+type RiskControlConfig struct {
+	// Enabled is the master switch for all hard risk gates. Pointer so that an
+	// absent config field defaults to enabled (true); set `enabled: false` to
+	// explicitly disable. Individual checks are still no-ops until their
+	// thresholds are set to positive values.
+	Enabled *bool `json:"enabled"`
+
+	// MaxLeverage caps the effective leverage used to open/add a position.
+	// Orders whose leverage exceeds this are rejected. Zero disables the check.
+	MaxLeverage fixedpoint.Value `json:"max_leverage"`
+
+	// MaxOrderQuote caps the notional (in quote currency) of a single open/add
+	// order. Zero disables the check.
+	MaxOrderQuote fixedpoint.Value `json:"max_order_quote"`
+
+	// MaxPositionQuote caps the total notional (in quote currency) of the
+	// resulting position (existing exposure + this order). Zero disables it.
+	MaxPositionQuote fixedpoint.Value `json:"max_position_quote"`
+
+	// MaxDailyLoss is the absolute realized loss (quote currency, positive
+	// number) that trips the daily kill-switch. Once tripped, all new
+	// open/add orders are rejected for the remainder of the trading day. The
+	// state resets automatically at the next trading day. Zero disables it.
+	MaxDailyLoss fixedpoint.Value `json:"max_daily_loss"`
+
+	// AutoCloseOnKill, when true, would close open positions on kill-switch
+	// trip. This is an ACTIVE fund action and is intentionally NOT performed
+	// autonomously by this code (requires owner approval); the flag is kept
+	// for forward compatibility and only emits an alert. Default false.
+	AutoCloseOnKill bool `json:"auto_close_on_kill"`
+}
+
+// IsEnabled reports whether the hard risk gate is active. Defaults to true
+// when the config omits the `enabled` field.
+func (c RiskControlConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
 }

--- a/pkg/env/exchange/exchange_entity.go
+++ b/pkg/env/exchange/exchange_entity.go
@@ -25,7 +25,7 @@ var log = logrus.WithField("entity", "exchange")
 
 const (
 	// Dynamic indicator limits
-	MaxDynamicIndicatorsPerCycle = 5
+	MaxDynamicIndicatorsPerCycle  = 5
 	DynamicIndicatorCycleDuration = 15 * time.Minute
 
 	// Default parameter values
@@ -49,6 +49,7 @@ type ExchangeEntity struct {
 	session       *bbgo.ExchangeSession
 	orderExecutor *bbgo.GeneralOrderExecutor
 	position      *PositionX
+	riskGate      *RiskGate
 
 	Status      types.StrategyStatus
 	Indicators  []*ExchangeIndicator
@@ -77,6 +78,7 @@ func NewExchangeEntity(
 		session:       session,
 		orderExecutor: orderExecutor,
 		position:      NewPositionX(position),
+		riskGate:      NewRiskGate(cfg.RiskControl),
 		vm:            goja.New(),
 	}
 }
@@ -959,6 +961,16 @@ func (ent *ExchangeEntity) Run(ctx context.Context, ch chan ttypes.IEvent) {
 
 			ent.updatePositionFundRatios(ctx, fixedpoint.NewFromFloat(exitPrice))
 
+			// Feed realized PnL to the hard risk gate so the daily-loss
+			// kill-switch (issue #86 / KR3) can trip. Recording only; no order.
+			if ent.riskGate != nil {
+				ent.riskGate.RecordRealizedPnL(ent.position.AccumulatedProfitValue)
+				if ent.riskGate.KillSwitchActive() {
+					log.Warnf("risk_gate: daily-loss kill-switch is ACTIVE for %s; new open orders will be rejected until next trading day", ent.symbol)
+					bbgo.Notify("[RISK] daily-loss kill-switch ACTIVE for %s; blocking new opens until next trading day", ent.symbol)
+				}
+			}
+
 			// Emit the position closed event
 			go func() {
 				log.WithField("positionData", positionData).Info("Emitting position_closed event")
@@ -1297,6 +1309,34 @@ func (s *ExchangeEntity) OpenPosition(ctx context.Context, side types.SideType, 
 		}
 	}
 
+	// Hard risk gate (issue #86 / KR3): a code-level, LLM-independent defensive
+	// check. If any configured limit is breached the order is rejected here and
+	// NOT submitted. This never triggers any active order/close on its own.
+	if s.riskGate != nil {
+		orderNotional := s.calculateOrderNotional(ctx, quoteRatio)
+		positionNotional := s.position.GetBase().Abs().Mul(closePrice)
+		decision := s.riskGate.Evaluate(orderNotional, positionNotional, s.leverage)
+		if !decision.Allow {
+			log.WithFields(logrus.Fields{
+				"symbol":            s.symbol,
+				"reason_code":       decision.Code,
+				"order_notional":    orderNotional.Float64(),
+				"position_notional": positionNotional.Float64(),
+				"leverage":          s.leverage.Float64(),
+			}).Errorf("risk_gate: rejecting open position order: %s", decision.Reason)
+			bbgo.Notify("[RISK] rejecting %s open order: %s", s.symbol, decision.Reason)
+
+			if decision.Code == RiskCodeKillSwitch && s.cfg.RiskControl.AutoCloseOnKill {
+				// Auto-close is an ACTIVE fund action; intentionally NOT performed
+				// autonomously (requires owner approval). Alert only.
+				log.Warnf("risk_gate: auto_close_on_kill is set but auto-close is intentionally disabled in code (requires owner approval); no close order submitted for %s", s.symbol)
+				bbgo.Notify("[RISK] kill-switch tripped for %s; auto-close requested but NOT executed (needs owner approval)", s.symbol)
+			}
+
+			return fmt.Errorf("risk gate rejected %s open order [%s]: %s", s.symbol, decision.Code, decision.Reason)
+		}
+	}
+
 	quantity := s.calculateQuantity(ctx, closePrice, side, quoteRatio)
 
 	for {
@@ -1522,6 +1562,28 @@ func (s *ExchangeEntity) generateOrderForm(side types.SideType, quantity fixedpo
 	}
 
 	return orderForm
+}
+
+// calculateOrderNotional returns the intended notional (in quote currency) of a
+// new open/add order, i.e. the leveraged quote budget the order will deploy.
+// It mirrors the quote budget used by calculateQuantity and is used only by the
+// hard risk gate (read-only; never places an order).
+func (s *ExchangeEntity) calculateOrderNotional(ctx context.Context, quoteRatio *fixedpoint.Value) fixedpoint.Value {
+	quoteQty, err := bbgo.CalculateQuoteQuantity(ctx, s.session, s.position.Market.QuoteCurrency, s.leverage)
+	if err != nil {
+		log.WithError(err).Errorf("risk_gate: can not read %s quote balance for notional", s.symbol)
+		return fixedpoint.Zero
+	}
+
+	if quoteRatio != nil && quoteRatio.Compare(fixedpoint.Zero) > 0 {
+		ratio := *quoteRatio
+		if ratio.Compare(fixedpoint.One) > 0 {
+			ratio = fixedpoint.One
+		}
+		quoteQty = quoteQty.Mul(ratio)
+	}
+
+	return quoteQty
 }
 
 // calculateQuantity returns leveraged quantity

--- a/pkg/env/exchange/risk_gate.go
+++ b/pkg/env/exchange/risk_gate.go
@@ -1,0 +1,218 @@
+package exchange
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+
+	"github.com/yubing744/trading-gpt/pkg/config"
+)
+
+// RiskEvalInput is the full set of inputs the pure risk evaluation needs to
+// decide whether to allow an open/add order. All monetary values are in the
+// quote currency; DailyRealizedPnL is signed (negative == loss).
+type RiskEvalInput struct {
+	// OrderNotional is the notional of the order being submitted (quote).
+	OrderNotional fixedpoint.Value
+	// PositionNotional is the notional of the currently-open position (quote, abs).
+	PositionNotional fixedpoint.Value
+	// Leverage is the effective leverage used for this order.
+	Leverage fixedpoint.Value
+	// DailyRealizedPnL is today's accumulated realized PnL (quote, signed).
+	DailyRealizedPnL fixedpoint.Value
+	// KillSwitchLatched is true when the daily kill-switch has already tripped
+	// earlier today (latched by the stateful gate). Once latched it stays deny
+	// until the trading day resets.
+	KillSwitchLatched bool
+}
+
+// RiskDecision is the result of a pure risk evaluation.
+type RiskDecision struct {
+	Allow  bool
+	Code   string // machine-readable reason code ("" when allowed)
+	Reason string // human-readable explanation
+}
+
+const (
+	RiskCodeKillSwitch  = "daily_loss_kill_switch"
+	RiskCodeMaxLeverage = "max_leverage_exceeded"
+	RiskCodeMaxOrder    = "max_order_notional_exceeded"
+	RiskCodeMaxPosition = "max_position_notional_exceeded"
+)
+
+// dailyLossTripped reports whether today's realized loss has reached the
+// configured MaxDailyLoss threshold. Loss magnitude is the negation of a
+// negative PnL; a zero/positive PnL is never a loss.
+func dailyLossTripped(dailyPnL, maxDailyLoss fixedpoint.Value) bool {
+	if maxDailyLoss.Sign() <= 0 { // check disabled
+		return false
+	}
+	if dailyPnL.Sign() >= 0 { // no loss
+		return false
+	}
+	loss := dailyPnL.Neg()
+	return loss.Compare(maxDailyLoss) >= 0
+}
+
+// EvaluateRisk is a pure function: given the current exposure/leverage, today's
+// realized PnL and the risk config, it returns an allow/deny decision with a
+// reason. It performs no I/O and never triggers any order — a deny simply means
+// the caller must not submit the order. Checks are evaluated most-protective
+// first (kill-switch), then leverage, single-order notional, total notional.
+func EvaluateRisk(in RiskEvalInput, cfg config.RiskControlConfig) RiskDecision {
+	if !cfg.IsEnabled() {
+		return RiskDecision{Allow: true}
+	}
+
+	// 1) Daily-loss kill-switch: latched, or freshly tripped by today's PnL.
+	if in.KillSwitchLatched || dailyLossTripped(in.DailyRealizedPnL, cfg.MaxDailyLoss) {
+		loss := fixedpoint.Zero
+		if in.DailyRealizedPnL.Sign() < 0 {
+			loss = in.DailyRealizedPnL.Neg()
+		}
+		return RiskDecision{
+			Allow: false,
+			Code:  RiskCodeKillSwitch,
+			Reason: fmt.Sprintf(
+				"daily loss kill-switch active: realized daily loss %.4f >= limit %.4f",
+				loss.Float64(), cfg.MaxDailyLoss.Float64()),
+		}
+	}
+
+	// 2) Leverage cap.
+	if cfg.MaxLeverage.Sign() > 0 && in.Leverage.Compare(cfg.MaxLeverage) > 0 {
+		return RiskDecision{
+			Allow: false,
+			Code:  RiskCodeMaxLeverage,
+			Reason: fmt.Sprintf(
+				"effective leverage %.4f exceeds max_leverage %.4f",
+				in.Leverage.Float64(), cfg.MaxLeverage.Float64()),
+		}
+	}
+
+	// 3) Single-order notional cap.
+	if cfg.MaxOrderQuote.Sign() > 0 && in.OrderNotional.Compare(cfg.MaxOrderQuote) > 0 {
+		return RiskDecision{
+			Allow: false,
+			Code:  RiskCodeMaxOrder,
+			Reason: fmt.Sprintf(
+				"order notional %.4f exceeds max_order_quote %.4f",
+				in.OrderNotional.Float64(), cfg.MaxOrderQuote.Float64()),
+		}
+	}
+
+	// 4) Total (resulting) position notional cap.
+	if cfg.MaxPositionQuote.Sign() > 0 {
+		total := in.PositionNotional.Add(in.OrderNotional)
+		if total.Compare(cfg.MaxPositionQuote) > 0 {
+			return RiskDecision{
+				Allow: false,
+				Code:  RiskCodeMaxPosition,
+				Reason: fmt.Sprintf(
+					"resulting position notional %.4f (existing %.4f + order %.4f) exceeds max_position_quote %.4f",
+					total.Float64(), in.PositionNotional.Float64(), in.OrderNotional.Float64(),
+					cfg.MaxPositionQuote.Float64()),
+			}
+		}
+	}
+
+	return RiskDecision{Allow: true}
+}
+
+// RiskGate is the stateful wrapper around EvaluateRisk. It tracks today's
+// realized PnL and latches the daily kill-switch, resetting both at each new
+// trading day. It is safe for concurrent use.
+type RiskGate struct {
+	cfg config.RiskControlConfig
+
+	mu            sync.Mutex
+	day           time.Time // truncated to the day currently being tracked
+	dailyRealized fixedpoint.Value
+	killLatched   bool
+
+	// now is injectable for deterministic tests; defaults to time.Now (UTC).
+	now func() time.Time
+}
+
+// NewRiskGate creates a RiskGate for the given config.
+func NewRiskGate(cfg config.RiskControlConfig) *RiskGate {
+	g := &RiskGate{
+		cfg: cfg,
+		now: func() time.Time { return time.Now().UTC() },
+	}
+	g.day = truncateDay(g.now())
+	return g
+}
+
+func truncateDay(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// rolloverLocked resets the daily state when the trading day has changed.
+// Caller must hold g.mu.
+func (g *RiskGate) rolloverLocked() {
+	today := truncateDay(g.now())
+	if !today.Equal(g.day) {
+		g.day = today
+		g.dailyRealized = fixedpoint.Zero
+		g.killLatched = false
+	}
+}
+
+// RecordRealizedPnL accumulates a realized PnL (signed; negative == loss) for
+// the current trading day and latches the kill-switch if the daily loss limit
+// is reached. This is invoked when a position is closed. It never submits any
+// order.
+func (g *RiskGate) RecordRealizedPnL(pnl fixedpoint.Value) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.rolloverLocked()
+	g.dailyRealized = g.dailyRealized.Add(pnl)
+
+	if !g.killLatched && dailyLossTripped(g.dailyRealized, g.cfg.MaxDailyLoss) {
+		g.killLatched = true
+	}
+}
+
+// Evaluate applies the hard risk gate to a prospective open/add order.
+// orderNotional and positionNotional are in quote currency; leverage is the
+// effective leverage for the order. It is a defensive check only.
+func (g *RiskGate) Evaluate(orderNotional, positionNotional, leverage fixedpoint.Value) RiskDecision {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.rolloverLocked()
+
+	// Refresh the latch in case the threshold is already exceeded.
+	if !g.killLatched && dailyLossTripped(g.dailyRealized, g.cfg.MaxDailyLoss) {
+		g.killLatched = true
+	}
+
+	return EvaluateRisk(RiskEvalInput{
+		OrderNotional:     orderNotional,
+		PositionNotional:  positionNotional,
+		Leverage:          leverage,
+		DailyRealizedPnL:  g.dailyRealized,
+		KillSwitchLatched: g.killLatched,
+	}, g.cfg)
+}
+
+// DailyRealizedPnL returns today's accumulated realized PnL (after rollover).
+func (g *RiskGate) DailyRealizedPnL() fixedpoint.Value {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.rolloverLocked()
+	return g.dailyRealized
+}
+
+// KillSwitchActive reports whether the daily kill-switch is currently latched.
+func (g *RiskGate) KillSwitchActive() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.rolloverLocked()
+	return g.killLatched
+}

--- a/pkg/env/exchange/risk_gate_test.go
+++ b/pkg/env/exchange/risk_gate_test.go
@@ -1,0 +1,250 @@
+package exchange
+
+import (
+	"testing"
+	"time"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+
+	"github.com/yubing744/trading-gpt/pkg/config"
+)
+
+func fp(f float64) fixedpoint.Value { return fixedpoint.NewFromFloat(f) }
+
+func boolPtr(b bool) *bool { return &b }
+
+// baseCfg is a fully-configured (all limits set) gate config used by most tests.
+func baseCfg() config.RiskControlConfig {
+	return config.RiskControlConfig{
+		Enabled:          boolPtr(true),
+		MaxLeverage:      fp(3),
+		MaxOrderQuote:    fp(100),
+		MaxPositionQuote: fp(150),
+		MaxDailyLoss:     fp(50),
+	}
+}
+
+func TestEvaluateRisk_AllowsWithinAllLimits(t *testing.T) {
+	in := RiskEvalInput{
+		OrderNotional:    fp(45),
+		PositionNotional: fp(0),
+		Leverage:         fp(3),
+		DailyRealizedPnL: fp(-10),
+	}
+	d := EvaluateRisk(in, baseCfg())
+	if !d.Allow {
+		t.Fatalf("expected allow, got deny: %s", d.Reason)
+	}
+	if d.Code != "" {
+		t.Fatalf("expected empty code on allow, got %q", d.Code)
+	}
+}
+
+func TestEvaluateRisk_DisabledMasterSwitchAllowsEverything(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Enabled = boolPtr(false)
+	in := RiskEvalInput{
+		OrderNotional:     fp(10000),
+		PositionNotional:  fp(10000),
+		Leverage:          fp(100),
+		DailyRealizedPnL:  fp(-9999),
+		KillSwitchLatched: true,
+	}
+	if d := EvaluateRisk(in, cfg); !d.Allow {
+		t.Fatalf("disabled gate must allow, got deny: %s", d.Reason)
+	}
+}
+
+func TestEvaluateRisk_ZeroThresholdsDisableIndividualChecks(t *testing.T) {
+	// Enabled but no thresholds set -> everything allowed (no behaviour change).
+	cfg := config.RiskControlConfig{Enabled: boolPtr(true)}
+	in := RiskEvalInput{
+		OrderNotional:    fp(1e9),
+		PositionNotional: fp(1e9),
+		Leverage:         fp(125),
+		DailyRealizedPnL: fp(-1e9),
+	}
+	if d := EvaluateRisk(in, cfg); !d.Allow {
+		t.Fatalf("zero thresholds must allow, got deny: %s", d.Reason)
+	}
+}
+
+func TestEvaluateRisk_MaxLeverage(t *testing.T) {
+	cfg := baseCfg()
+	// exactly at limit -> allowed
+	if d := EvaluateRisk(RiskEvalInput{Leverage: fp(3), OrderNotional: fp(1)}, cfg); !d.Allow {
+		t.Fatalf("leverage at limit must be allowed")
+	}
+	// just above -> denied
+	d := EvaluateRisk(RiskEvalInput{Leverage: fp(3.0001), OrderNotional: fp(1)}, cfg)
+	if d.Allow || d.Code != RiskCodeMaxLeverage {
+		t.Fatalf("expected max_leverage deny, got allow=%v code=%s", d.Allow, d.Code)
+	}
+}
+
+func TestEvaluateRisk_MaxOrderQuote(t *testing.T) {
+	cfg := baseCfg()
+	if d := EvaluateRisk(RiskEvalInput{OrderNotional: fp(100), Leverage: fp(1)}, cfg); !d.Allow {
+		t.Fatalf("order notional at limit must be allowed")
+	}
+	d := EvaluateRisk(RiskEvalInput{OrderNotional: fp(100.01), Leverage: fp(1)}, cfg)
+	if d.Allow || d.Code != RiskCodeMaxOrder {
+		t.Fatalf("expected max_order deny, got allow=%v code=%s", d.Allow, d.Code)
+	}
+}
+
+func TestEvaluateRisk_MaxPositionQuote(t *testing.T) {
+	cfg := baseCfg()
+	// existing 120 + order 30 = 150 == limit -> allowed
+	if d := EvaluateRisk(RiskEvalInput{PositionNotional: fp(120), OrderNotional: fp(30), Leverage: fp(1)}, cfg); !d.Allow {
+		t.Fatalf("total notional at limit must be allowed")
+	}
+	// existing 120 + order 31 = 151 > 150 -> denied
+	d := EvaluateRisk(RiskEvalInput{PositionNotional: fp(120), OrderNotional: fp(31), Leverage: fp(1)}, cfg)
+	if d.Allow || d.Code != RiskCodeMaxPosition {
+		t.Fatalf("expected max_position deny, got allow=%v code=%s", d.Allow, d.Code)
+	}
+}
+
+func TestEvaluateRisk_KillSwitchFromDailyLoss(t *testing.T) {
+	cfg := baseCfg() // MaxDailyLoss = 50
+	// loss of 49 -> still allowed
+	if d := EvaluateRisk(RiskEvalInput{DailyRealizedPnL: fp(-49), OrderNotional: fp(1), Leverage: fp(1)}, cfg); !d.Allow {
+		t.Fatalf("loss below limit must be allowed")
+	}
+	// loss of exactly 50 -> tripped
+	d := EvaluateRisk(RiskEvalInput{DailyRealizedPnL: fp(-50), OrderNotional: fp(1), Leverage: fp(1)}, cfg)
+	if d.Allow || d.Code != RiskCodeKillSwitch {
+		t.Fatalf("loss at limit must trip kill-switch, got allow=%v code=%s", d.Allow, d.Code)
+	}
+	// profit -> not tripped
+	if d := EvaluateRisk(RiskEvalInput{DailyRealizedPnL: fp(1000), OrderNotional: fp(1), Leverage: fp(1)}, cfg); !d.Allow {
+		t.Fatalf("profit must never trip kill-switch")
+	}
+}
+
+func TestEvaluateRisk_LatchedKillSwitchDeniesEvenWithoutLoss(t *testing.T) {
+	cfg := baseCfg()
+	d := EvaluateRisk(RiskEvalInput{
+		DailyRealizedPnL:  fp(0),
+		KillSwitchLatched: true,
+		OrderNotional:     fp(1),
+		Leverage:          fp(1),
+	}, cfg)
+	if d.Allow || d.Code != RiskCodeKillSwitch {
+		t.Fatalf("latched kill-switch must deny, got allow=%v code=%s", d.Allow, d.Code)
+	}
+}
+
+func TestEvaluateRisk_KillSwitchTakesPrecedence(t *testing.T) {
+	// Even if leverage/notional are fine, a tripped kill-switch denies first.
+	cfg := baseCfg()
+	d := EvaluateRisk(RiskEvalInput{
+		DailyRealizedPnL: fp(-60),
+		OrderNotional:    fp(1),
+		Leverage:         fp(1),
+	}, cfg)
+	if d.Code != RiskCodeKillSwitch {
+		t.Fatalf("kill-switch must take precedence, got code=%s", d.Code)
+	}
+}
+
+// --- Stateful RiskGate tests ---
+
+func newGateAt(cfg config.RiskControlConfig, clock *time.Time) *RiskGate {
+	g := NewRiskGate(cfg)
+	g.now = func() time.Time { return *clock }
+	*clock = time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	g.day = truncateDay(*clock)
+	return g
+}
+
+func TestRiskGate_RecordAndTripKillSwitch(t *testing.T) {
+	clock := time.Now()
+	g := newGateAt(baseCfg(), &clock)
+
+	g.RecordRealizedPnL(fp(-20))
+	if g.KillSwitchActive() {
+		t.Fatalf("should not be tripped after -20 (< 50)")
+	}
+	g.RecordRealizedPnL(fp(-35)) // cumulative -55 >= 50
+	if !g.KillSwitchActive() {
+		t.Fatalf("should be tripped after cumulative -55")
+	}
+
+	d := g.Evaluate(fp(10), fp(0), fp(1))
+	if d.Allow || d.Code != RiskCodeKillSwitch {
+		t.Fatalf("gate must deny while kill-switch latched, got allow=%v code=%s", d.Allow, d.Code)
+	}
+}
+
+func TestRiskGate_KillSwitchLatchesDespiteRecovery(t *testing.T) {
+	clock := time.Now()
+	g := newGateAt(baseCfg(), &clock)
+
+	g.RecordRealizedPnL(fp(-60)) // trip
+	g.RecordRealizedPnL(fp(100)) // recover to +40 same day
+	if !g.KillSwitchActive() {
+		t.Fatalf("kill-switch must stay latched for the rest of the day despite recovery")
+	}
+	if d := g.Evaluate(fp(10), fp(0), fp(1)); d.Allow {
+		t.Fatalf("gate must keep denying while latched same day")
+	}
+}
+
+func TestRiskGate_ResetsOnNewTradingDay(t *testing.T) {
+	clock := time.Now()
+	g := newGateAt(baseCfg(), &clock)
+
+	g.RecordRealizedPnL(fp(-60)) // trip today
+	if !g.KillSwitchActive() {
+		t.Fatalf("expected tripped on day 1")
+	}
+
+	// advance to next day
+	clock = time.Date(2026, 7, 14, 0, 0, 1, 0, time.UTC)
+
+	if g.KillSwitchActive() {
+		t.Fatalf("kill-switch must reset on new trading day")
+	}
+	if g.DailyRealizedPnL().Sign() != 0 {
+		t.Fatalf("daily realized PnL must reset to zero on new day, got %v", g.DailyRealizedPnL().Float64())
+	}
+	if d := g.Evaluate(fp(45), fp(0), fp(3)); !d.Allow {
+		t.Fatalf("gate must allow normal order on the new day, got deny: %s", d.Reason)
+	}
+}
+
+func TestRiskGate_NotionalChecksThroughGate(t *testing.T) {
+	clock := time.Now()
+	g := newGateAt(baseCfg(), &clock)
+
+	if d := g.Evaluate(fp(45), fp(0), fp(3)); !d.Allow {
+		t.Fatalf("normal order must be allowed")
+	}
+	if d := g.Evaluate(fp(200), fp(0), fp(3)); d.Allow || d.Code != RiskCodeMaxOrder {
+		t.Fatalf("oversized single order must be denied, got allow=%v code=%s", d.Allow, d.Code)
+	}
+	if d := g.Evaluate(fp(40), fp(120), fp(3)); d.Allow || d.Code != RiskCodeMaxPosition {
+		t.Fatalf("oversized total must be denied, got allow=%v code=%s", d.Allow, d.Code)
+	}
+}
+
+func TestRiskGate_DefaultEnabledWhenNil(t *testing.T) {
+	cfg := config.RiskControlConfig{MaxDailyLoss: fp(50)} // Enabled nil -> true
+	clock := time.Now()
+	g := newGateAt(cfg, &clock)
+	g.RecordRealizedPnL(fp(-60))
+	if d := g.Evaluate(fp(1), fp(0), fp(1)); d.Allow {
+		t.Fatalf("nil Enabled must default to enabled; kill-switch should deny")
+	}
+}
+
+func TestRiskControlConfig_IsEnabled(t *testing.T) {
+	if !(config.RiskControlConfig{}).IsEnabled() {
+		t.Fatalf("nil Enabled must default to true")
+	}
+	if (config.RiskControlConfig{Enabled: boolPtr(false)}).IsEnabled() {
+		t.Fatalf("explicit false must disable")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **code-level, LLM-independent hard risk-control gate** in front of every open/add order (`ExchangeEntity.OpenPosition` → before `SubmitOrders`). Any breached limit **rejects the order (defensive deny) and never triggers an active order**. Closes the gap where the LLM was the only line of defense — a misjudgment or a losing streak had no code-level guardrail. This is **KR3 (硬风控)** of the `hexagram-deepseek-test` OKR.

Fixes / addresses #86.

## Root cause (no-guardrail points)

- `pkg/env/exchange/exchange_entity.go` — `OpenPosition` submits orders after only a `MinQuantity` floor check (`quantity.Compare(s.position.Market.MinQuantity) < 0`). There is **no size/notional cap, no leverage cap, no daily-loss / kill-switch** anywhere before `orderExecutor.SubmitOrders`.
- Sizing (`calculateQuantity`) simply multiplies balance by `s.leverage` (`bbgo.CalculateQuoteQuantity(..., s.leverage)`) with no upper bound.
- Result: whatever the LLM decides is placed, unbounded.

## What was added

- **`pkg/config/env_exchange_config.go`** — `RiskControlConfig` under `exchange.risk_control`:
  - `enabled` (`*bool`, **default true** when omitted; set `false` to disable)
  - `max_leverage` — effective leverage cap
  - `max_order_quote` — single open/add order notional cap (quote)
  - `max_position_quote` — total resulting position notional cap (quote)
  - `max_daily_loss` — daily realized-loss threshold that trips the kill-switch (quote, positive number)
  - `auto_close_on_kill` (**default false**, see below)
- **`pkg/env/exchange/risk_gate.go`**
  - `EvaluateRisk(in, cfg) RiskDecision` — **pure function**, no I/O, returns allow/deny + reason. Order of checks (most-protective first): kill-switch → leverage → single-order notional → total notional.
  - `RiskGate` — stateful wrapper that tracks today's realized PnL, **latches** the kill-switch for the rest of the trading day, and **auto-resets on the next trading day** (UTC). Safe for concurrent use.
- **`OpenPosition`** now calls `riskGate.Evaluate(...)` before submitting; on deny it logs, alerts (`bbgo.Notify`), and returns an error **without placing the order**. Realized PnL is fed to the gate on position close (`OnPositionUpdate` → `RecordRealizedPnL`).

### Kill-switch semantics
Tracks cumulative daily realized PnL. When realized daily loss ≥ `max_daily_loss`, the switch **latches** → all new opens/adds are rejected until the next trading day (resets automatically). Once latched it stays latched for the day even if PnL partially recovers (conservative). Profit never trips it.

### Safe defaults (no behaviour change out-of-the-box)
- Master `enabled` defaults **true**, but **each limit is disabled when its threshold is zero/unset**, so an unconfigured deployment keeps its exact prior behaviour. Operators tighten the gate by setting positive thresholds sized to the live account (e.g. KR1 baseline: notional ~45, 3x leverage → set `max_order_quote`/`max_position_quote`/`max_leverage`/`max_daily_loss` accordingly).

## Defensive vs. active actions

- **Defensive rejection only (auto-mergeable):** all four gates reject/deny + alert. They **never place any order** (no new opens, no auto-closes).
- **Active fund action (default OFF, needs owner approval):** `auto_close_on_kill` is intentionally **NOT executed autonomously** — when set it only emits an alert; no close order is submitted. Automatically flattening real positions is a fund-moving action that requires owner sign-off.

## Testing

- `GOTOOLCHAIN=go1.22.0 go test ./pkg/... -count=1` → all packages **PASS** (15 new risk-gate test cases: each limit boundary, kill-switch trip/latch/reset, precedence, disabled/zero-threshold pass-through, config default-enabled).
- `go vet ./pkg/...` clean, `go build ./...` PASS, `gofmt` clean.

## Scope / boundaries

Code + tests + config only. No live/infra changes, no submodule bumps, no order placement. Purely additive; unrelated code untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
